### PR TITLE
appveyor: Update apt-get

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ build: off
 test: off
 
 init:
+  - sudo apt-get update --fix-missing
   - sudo apt-get -y install git cmake gcc-mingw-w64 g++-mingw-w64 autoconf libtool pkg-config libglib2.0-dev gnome-common gtk-doc-tools libgtk2.0-dev ocaml ocamlbuild fig2dev texinfo
 
 build_script:


### PR DESCRIPTION
This fixes issue on appveyor where libxml2 can't be found.

Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2-utils_2.9.4+dfsg1-6.1ubuntu1.2_amd64.deb  404  Not Found.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>