### PR TITLE
buid.sh.inc: Include missing icon (window-new.svg)

### DIFF
--- a/build.sh.inc
+++ b/build.sh.inc
@@ -414,6 +414,11 @@ remove_garbage () {
 	rm -rf ${SYSROOT}/${INSTALL_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders/!(*.dll)
 }
 
+handle_resources () {
+	mkdir -p ${SYSROOT}/${INSTALL_PREFIX}/share/icons
+	cp /usr/share/icons/Humanity/actions/24/window-new.svg ${SYSROOT}/${INSTALL_PREFIX}/share/icons/
+}
+
 # Strip!
 	strip () {
 	${HOST}-strip ${SYSROOT}/${INSTALL_PREFIX}/bin/*.dll
@@ -453,6 +458,7 @@ main () {
 	build_curl
 	build_jansson
 	#remove_garbage
+	handle_resources
 	strip
 
 	echo "Build complete."


### PR DESCRIPTION
The window-new.svg icon is used by iio-oscilloscope in the 'Capture' window. This icon is provided by a theme which is usually installed on a host but does the theme exist on Windows.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>

Partially fixes:
https://github.com/analogdevicesinc/iio-oscilloscope/issues/146