### PR TITLE
libad9166: add support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,6 +17,9 @@
 [submodule "libad9361"]
 	path = libad9361
 	url = https://github.com/analogdevicesinc/libad9361-iio.git
+[submodule "libad9166"]
+	path = libad9166
+	url = https://github.com/analogdevicesinc/libad9166-iio.git
 [submodule "libserialport"]
 	path = libserialport
 	url = git://sigrok.org/libserialport

--- a/build.sh.inc
+++ b/build.sh.inc
@@ -336,6 +336,15 @@ build_libad9361 () {
 	make install
 }
 
+# Build libad9166
+build_libad9166 () {
+	cd ${CURDIR}/libad9166
+	rm -rf build && mkdir build && cd build
+	cmake_build
+	make ${MAKE_J}
+	make install
+}
+
 # Build matio
 build_matio () {
 	cd ${CURDIR}/matio

--- a/build.sh.inc
+++ b/build.sh.inc
@@ -141,7 +141,7 @@ build_gettext () {
 # Build libpng
 build_libpng () {
 	cd ${CURDIR}
-	[ ! -d libpng-${LIBPNG_VERSION} ] && wget ftp://ftp.simplesystems.org/pub/png/src/history/libpng15/libpng-${LIBPNG_VERSION}.tar.xz -O- |tar xJf -
+	[ ! -d libpng-${LIBPNG_VERSION} ] && wget https://download.sourceforge.net/libpng/libpng-${LIBPNG_VERSION}.tar.xz -O- |tar xJf -
 	cd ${CURDIR}/libpng-${LIBPNG_VERSION}
 	./configure ${CONFIGURE_OPTS}
 	make clean


### PR DESCRIPTION
Add support for the libad9166-iio repository, required for the appveyor
build of the IIO-Oscilloscope.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>