### PR TITLE
buid.sh.inc: Build libad9166

### DIFF
--- a/build.sh.inc
+++ b/build.sh.inc
@@ -464,6 +464,7 @@ main () {
 	build_libusb
 	build_libiio
 	build_libad9361
+	build_libad9166
 	build_matio
 	build_fftw3
 	build_gtkdatabox


### PR DESCRIPTION
build_libad9166() was created but never called.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>